### PR TITLE
Fix misleading version label

### DIFF
--- a/mRemoteNG/UI/Window/UpdateWindow.cs
+++ b/mRemoteNG/UI/Window/UpdateWindow.cs
@@ -68,7 +68,7 @@ namespace mRemoteNG.UI.Window
                 : Language.DownloadAndInstall;
             lblChangeLogLabel.Text = Language.Changelog;
             lblInstalledVersion.Text = Language.Version;
-            lblInstalledVersionLabel.Text = $"{Language.AvailableVersion}:";
+            lblInstalledVersionLabel.Text = $"{Language.Version}:";
             lblLatestVersion.Text = Language.Version;
             lblLatestVersionLabel.Text = $"{Language.AvailableVersion}:";
         }


### PR DESCRIPTION
Currently, both the `lblInstalledVersionLabel` and the `lblLatestVersionLabel` show the text `Latest version`.

This is quite misleading as one of them displays the currently installed version while the other shows the latest version available on the internet.

Changes made in this PR will change the label of `lblInstalledVersionLabel` to `Version` and leave `lblLatestVersionLabel` unchanged (i.e. making it say `Latest Version`).